### PR TITLE
Related fields that are not in the form can now be used

### DIFF
--- a/src/lib/field/Field.js
+++ b/src/lib/field/Field.js
@@ -147,6 +147,7 @@ export default class Field {
   // Don't do it if you don't need it.
 
   // onUpdate (field, value, properties, callback) {}
+  // relatedFields () { return [...] }
 
   rules (t) {
     return [

--- a/src/lib/field/LinkedField.js
+++ b/src/lib/field/LinkedField.js
@@ -22,6 +22,12 @@ export default class LinkedField extends Field {
     this.sourceField = fields.find(f => f.name === this.source)
   }
 
+  relatedFields () {
+    return [
+      this.sourceField
+    ]
+  }
+
   getLinkedValue (value) {
     if (this.validValue(value) && this.sourceField.valuesDict) {
       value = this.sourceField.valuesDict[value]

--- a/src/lib/field/TableField.js
+++ b/src/lib/field/TableField.js
@@ -20,6 +20,12 @@ export default class TableField extends Field {
     this.uniqueField = fields.find(f => f.name === this.toField)
   }
 
+  relatedFields () {
+    return [
+      this.uniqueField
+    ]
+  }
+
   getValue (data) {
     return this.uniqueField.getValue(data)
   }

--- a/src/lib/table/TableInfo.js
+++ b/src/lib/table/TableInfo.js
@@ -23,6 +23,19 @@ export default class TableInfo {
     this.tableFields = this.strlist2fields(info.design.list_fields)
     this.formFields = this.strlist2fields(info.design.form_fields)
     this.logicFormFields = this.fields.filter(field => field.onUpdate || this.formFields.includes(field))
+    {
+      const related = new Set()
+      this.formFields.forEach(field => {
+        if (field.relatedFields) {
+          field.relatedFields().forEach(f => related.add(f))
+        }
+      })
+      related.forEach(f => {
+        if (!this.logicFormFields.includes(f)) {
+          this.logicFormFields.push(f)
+        }
+      })
+    }
 
     this.rowsPath = new DottedPath(info.objects_path)
     this.propsPath = new DottedPath(info.attributes_path)


### PR DESCRIPTION
The LinkedField and TableField's related fields are now added into the logicFormFields list.
This means thay can be used even if they are not visisble in the form.