### PR TITLE
Fix search: keep the results ordered by the search they are from

### DIFF
--- a/src/components/SearchPanel.vue
+++ b/src/components/SearchPanel.vue
@@ -64,7 +64,7 @@ export default {
       return this.$store.state.search.history
     },
     results () {
-      return this.$store.state.search.fetchingResults || this.$store.state.search.finalResults
+      return this.$store.getters['search/results']
     },
     state () {
       return this.$store.getters['search/state']

--- a/src/lib/search.js
+++ b/src/lib/search.js
@@ -75,21 +75,17 @@ export default class Search {
 
   search (q) {
     this.promises = []
-    this.results = Vue.observable([])
 
     this.setAllSearches(q)
 
-    this.promises.forEach(promise => {
+    this.results = Vue.observable(this.promises.map(() => []))
+
+    this.promises.forEach((promise, index) => {
       promise
         .then(result => {
-          // Save the result in this.results (flatten)
-          if (Array.isArray(result)) {
-            Array.prototype.push.apply(this.results, result)
-          } else {
-            this.results.push(result)
-          }
+          this.results[index] = result
         })
-        .catch(noop) // Will be propegated to the search. Not out reponsibility
+        .catch(noop) // Will be propegated to the search. Not our reponsibility
     })
 
     const search = Promise.all(this.promises).then(_ => this.results)

--- a/src/store/module-search/actions.js
+++ b/src/store/module-search/actions.js
@@ -39,7 +39,7 @@ export function fetch (context) {
 
   search
     .then(results => {
-      context.dispatch('finishResults', results)
+      context.dispatch('finishResults', results.flat())
     })
     .catch(error => {
       context.commit('errorFetching', true)

--- a/src/store/module-search/getters.js
+++ b/src/store/module-search/getters.js
@@ -1,7 +1,7 @@
 import { STATES } from './constants.js'
 
 export function results (state) {
-  return state.fetchingResults || state.finalResults
+  return state.finalResults || (state.fetchingResults && state.fetchingResults.flat())
 }
 
 export function state (state) {


### PR DESCRIPTION
This makes the results order consistent. It was not due to it being dependent of the response timming.