### PR TITLE
Bug fix: DateTimeField now expects the value to be in UTC format

### DIFF
--- a/src/lib/field/DateTimeField.js
+++ b/src/lib/field/DateTimeField.js
@@ -22,7 +22,7 @@ export default class DateTimeField extends Field {
     }
 
     if (!this.moment.isMoment(value)) {
-      value = this.moment.utc(value, this.format)
+      value = this.moment.utc(value)
     }
     return value
   }


### PR DESCRIPTION
It expected the server to give the value in the format set with the options (which is the use we use to show the user, not as input)