### PR TITLE
Fix check for gmaps being initialized

### DIFF
--- a/src/lib/gmaps.js
+++ b/src/lib/gmaps.js
@@ -5,7 +5,7 @@
 // const API_KEY = `AIzaSyCWAaBJsIvwbrbTI18PITVy7p0Qb6htM1k`
 const CALLBACK_NAME = `gmapsCallback`
 
-let initialized = !!window.google
+let initialized = !!(window.google && window.google.maps)
 let resolveInitPromise
 let rejectInitPromise
 // This promise handles the initialization


### PR DESCRIPTION
If some other google library has been initialized (e.g. translate), the check is no longer valid.