### PR TITLE
Prevent bulk timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4090,6 +4090,11 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -5077,6 +5082,11 @@
         "lru-cache": "^4.0.1",
         "which": "^1.2.9"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "crypto-browserify": {
       "version": "3.12.0",
@@ -12035,6 +12045,23 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+        }
       }
     },
     "md5.js": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "leaflet.markercluster": "^1.4.1",
     "leaflet.path.drag": "0.0.6",
     "leaflet.wms": "^0.2.0",
+    "md5": "^2.2.1",
     "microdisseny-leaflet-measure": "git+https://github.com/Microdisseny/microdisseny-leaflet-measure.git",
     "moment": "^2.24.0",
     "node-sass": "^4.13.0",

--- a/src/api/databaselayers.js
+++ b/src/api/databaselayers.js
@@ -1,5 +1,8 @@
 import axios from 'axios'
+import md5 from 'md5'
 import { throwUnhandledExceptions } from '../lib/promiseUtils.js'
+
+const requestCache = new WeakMap()
 
 export default {
   getLayerInfo (editSource, layer, config) {
@@ -54,11 +57,31 @@ export default {
       return Promise.resolve()
     }
     const url = target.source.url + `layerserver/databaselayers/${target.layer.name}/bulk/`
+
+    let request = requestCache.get(changes)
+    if (!request) {
+      request = {}
+      const changesRequest = {
+        ...changes,
+        _META: { time: Date.now() }
+      }
+      request.body = JSON.stringify(changesRequest)
+      request.hash = md5(request.body)
+      requestCache.set(changes, request)
+    }
+
     const conf = {
       timeout: 10000,
+      headers: {},
       ...config
     }
-    const request = axios.post(url, changes, conf)
-    return throwUnhandledExceptions(request)
+
+    conf.headers = {
+      ...conf.headers,
+      // 'X-Bulk-Hash': request.hash,
+      'Content-Type': 'application/json'
+    }
+
+    return throwUnhandledExceptions(axios.post(url, request.body, conf))
   }
 }

--- a/src/lib/table/SaveJob.js
+++ b/src/lib/table/SaveJob.js
@@ -11,6 +11,9 @@ export default class SaveJob extends AsyncJob {
   }
 
   saveChanges () {
-    return this.remote.save(this.rowChanges.repr())
+    if (!this.repr) {
+      this.repr = this.rowChanges.repr()
+    }
+    return this.remote.save(this.repr)
   }
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -113,6 +113,25 @@ export function escapeHtml (unsafe) {
     .replace(/'/g, '&#039;')
 }
 
+export function waitUntil (f, t = 1000) {
+  return new Promise((resolve, reject) => {
+    let done = false
+    const looper = setInterval(function () {
+      try {
+        if (f.apply(this) && !done) {
+          done = true
+          clearInterval(looper)
+          resolve()
+        }
+      } catch (e) {
+        done = true
+        clearInterval(looper)
+        reject(e)
+      }
+    }, t)
+  })
+}
+
 export const INTERNAL_PROPERTY = Object.freeze({
   configurable: true,
   enumerable: false,

--- a/src/store/module-data-layer/actions.js
+++ b/src/store/module-data-layer/actions.js
@@ -3,6 +3,8 @@ import clone from 'lodash/clone.js'
 import databaseLayersApi from '../../api/databaselayers.js'
 
 import { throwUnhandledExceptions } from '../../lib/promiseUtils.js'
+import { some } from '../../lib/itertools.js'
+import { waitUntil } from '../../lib/utils.js'
 
 export function invalidateState (context) {
   context.commit('setInitialState')
@@ -60,8 +62,25 @@ export function verifySourcesLoaded (context) {
   }
 }
 
+function _updateWMS (context) {
+  const table = context.state.table
+  if (!table.updateWmsRequested) return
+  table.updateWmsRequested = false
+  table.updateWMS()
+  const toRefresh = table.refLayers.filter(ref => ref.refresh).map(ref => ref.layer)
+  window.toRefresh = toRefresh
+  const promise = waitUntil(() => table !== context.state.table || !some(toRefresh, layer => layer.isLoading()))
+  context.commit('updateWms', promise)
+}
+
 function queueJob (context, asyncJob) {
-  context.state.asyncQueue.add(asyncJob).run()
+  context.state.asyncQueue.add(asyncJob)
+  context.state.updateWms.then(() => {
+    const promise = context.state.asyncQueue.run()
+    if (promise) {
+      promise.then(() => _updateWMS(context))
+    }
+  })
 }
 // Both use the same queue so it uses the same code to add the jobs
 export const uploadPhoto = queueJob

--- a/src/store/module-data-layer/mutations.js
+++ b/src/store/module-data-layer/mutations.js
@@ -23,3 +23,7 @@ export function clearLoadingSourceErrors (state) {
 export function addLoadingSourceError (state, error) {
   state.loadingSourceErrors.push(error)
 }
+
+export function updateWms (state, promise) {
+  state.updateWms = promise
+}

--- a/src/store/module-data-layer/state.js
+++ b/src/store/module-data-layer/state.js
@@ -4,5 +4,6 @@ export default {
   sources: null,
   loadingSourceErrors: [],
   table: null,
+  updateWms: Promise.resolve(),
   asyncQueue: new AsyncQueue()
 }


### PR DESCRIPTION
It waits to update the WMS until all the data is sent to the server. This prevents the WMS to take all the connection, timming the request out.
Also added a hash-based identification that may allow the server to resend the same result without applying it twice.