### PR TITLE
Fix table not detecting that rows have been edited

### DIFF
--- a/src/components/data-layer/TableDialog.vue
+++ b/src/components/data-layer/TableDialog.vue
@@ -92,9 +92,6 @@ export default {
   computed: {
     editing () {
       return this.table && this.table.editing
-    },
-    changed () {
-      return this.table && this.table.rows.some(row => row.status.new || row.status.edited || row.status.deleted)
     }
   },
   methods: {

--- a/src/lib/table/row/Row.js
+++ b/src/lib/table/row/Row.js
@@ -103,12 +103,13 @@ export default class Row {
   }
 
   resetStatus () {
-    this.status.deleted = false
-    this.status.edited = false
+    this.status._deleted = false
+    this.status._edited = false
     this.status.propsEdited = false
     this.status.geomEdited = false
     this.status.new = false
 
+    this._updateModified()
     this.applyStyle()
   }
 


### PR DESCRIPTION
New rows' modified flag was not being correctly set.

Also remove a red herring that is actually dead code.